### PR TITLE
Add Current Frequency metric to CPU metrics

### DIFF
--- a/internal/metric/cpu.go
+++ b/internal/metric/cpu.go
@@ -1,6 +1,8 @@
 package metric
 
 import (
+	"bluewave-uptime-agent/internal/sysfs"
+
 	"github.com/shirou/gopsutil/v4/cpu"
 )
 
@@ -42,12 +44,19 @@ func CollectCpuMetrics() (*CpuData, error) {
 	// 	return nil, cpuTempErr
 	// }
 
+	cpuCurrentFrequency, cpuCurFreqErr := sysfs.CpuCurrentFrequency()
+
+	if cpuCurFreqErr != nil {
+		return nil, cpuCurFreqErr
+	}
+
 	return &CpuData{
-		PhysicalCore: cpuPhysicalCoreCount,
-		LogicalCore:  cpuLogicalCoreCount,
-		Frequency:    cpuInformation[0].Mhz,
-		Temperature:  nil,
-		FreePercent:  1 - cpuUsagePercent,
-		UsagePercent: cpuUsagePercent,
+		PhysicalCore:     cpuPhysicalCoreCount,
+		LogicalCore:      cpuLogicalCoreCount,
+		Frequency:        cpuInformation[0].Mhz,
+		CurrentFrequency: cpuCurrentFrequency,
+		Temperature:      nil,
+		FreePercent:      1 - cpuUsagePercent,
+		UsagePercent:     cpuUsagePercent,
 	}, nil
 }

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -8,12 +8,13 @@ type ApiResponse struct {
 }
 
 type CpuData struct {
-	PhysicalCore int      `json:"physical_core"` // Physical cores
-	LogicalCore  int      `json:"logical_core"`  // Logical cores aka Threads
-	Frequency    float64  `json:"frequency"`     // Frequency in mHz
-	Temperature  *float32 `json:"temperauture"`  // Temperature in Celsius (nil if not available)
-	FreePercent  float64  `json:"free_percent"`  // Free percentage                               //* 1 - (Total - Idle / Total)
-	UsagePercent float64  `json:"usage_percent"` // Usage percentage                              //* Total - Idle / Total
+	PhysicalCore     int      `json:"physical_core"`     // Physical cores
+	LogicalCore      int      `json:"logical_core"`      // Logical cores aka Threads
+	Frequency        float64  `json:"frequency"`         // Frequency in mHz
+	CurrentFrequency int      `json:"current_frequency"` // Current Frequency in mHz
+	Temperature      *float32 `json:"temperauture"`      // Temperature in Celsius (nil if not available)
+	FreePercent      float64  `json:"free_percent"`      // Free percentage                               //* 1 - (Total - Idle / Total)
+	UsagePercent     float64  `json:"usage_percent"`     // Usage percentage                              //* Total - Idle / Total
 }
 
 type MemoryData struct {

--- a/internal/sysfs/cpu.go
+++ b/internal/sysfs/cpu.go
@@ -22,3 +22,21 @@ func CpuTemperature() (*float32, error) {
 	var temp_float = float32(temp) / 1000
 	return &temp_float, nil
 }
+
+func CpuCurrentFrequency() (int, error) {
+	frequency, cpuFrequencyError := ShellExec("cat /sys/devices/system/cpu/cpufreq/policy0/scaling_cur_freq")
+
+	if cpuFrequencyError != nil {
+		return 0, cpuFrequencyError
+	}
+
+	frequency = strings.TrimSuffix(frequency, "\n")
+	freq, strConvErr := strconv.Atoi(frequency)
+
+	if strConvErr != nil {
+		return 0, strConvErr
+	}
+
+	// Convert frequency to mHz
+	return freq / 1000, nil
+}


### PR DESCRIPTION
Resolves: #2 

Added new CpuCurrentFrequency function to `internal/sysfs` module for accessing the system-level CPU information. It's reading the current scaling frequency file then returns the current frequncy in `mHz`