### PR TITLE
Update websocket to handle data streaming at 5 seconds intervals | #4

### DIFF
--- a/internal/handler/websocket.go
+++ b/internal/handler/websocket.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"bluewave-uptime-agent/internal/metric"
+	"encoding/json"
 	"log"
 	"net/http"
 	"time"
@@ -9,7 +11,6 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-var data = []byte("BlueWave Uptime Hardware Monitor Agent")
 var interval = 2 * time.Second
 
 var upgrader = websocket.Upgrader{
@@ -35,8 +36,44 @@ func WebSocket(c *gin.Context) {
 	}
 
 	defer conn.Close()
+	done := make(chan struct{}) // Channel to signal when the client disconnects
+
+	// Goroutine to handle incoming messages and detect disconnection
+	go func() {
+		for {
+			_, _, err := conn.ReadMessage() // ReadMessage blocks until there's a message or an error
+			if err != nil {
+				log.Println("Client disconnected:", err)
+				close(done) // Signal that the client has disconnected
+				return
+			}
+		}
+	}()
+
+	// Streaming messages to the client
 	for {
-		conn.WriteMessage(websocket.TextMessage, data)
-		time.Sleep(interval)
+		metrics, metricsErr := metric.GetAllSystemMetrics()
+		if metricsErr != nil {
+			log.Printf("[FAIL] | Failed to get system metrics: %v", metricsErr)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get system metrics"})
+			return
+		}
+		data, dataErr := json.Marshal(metrics)
+		if dataErr != nil {
+			log.Printf("[FAIL] | Failed to marshal system metrics: %v", dataErr)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to marshal system metrics"})
+			return
+		}
+		select {
+		case <-done: // If client disconnects, exit the loop
+			log.Println("Stopped streaming due to client disconnect")
+			return
+		default:
+			if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
+				log.Println("Write error:", err)
+				return
+			}
+			time.Sleep(interval) // Simulate real-time data generation
+		}
 	}
 }

--- a/internal/handler/websocket.go
+++ b/internal/handler/websocket.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-var interval = 2 * time.Second
+var interval = 5 * time.Second
 
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,


### PR DESCRIPTION
Resolves: #4 

The `ws://localhost:3000/ws/metrics` endpoint streams the system metrics in every 5 seconds. This stream continues as long as the connection is not lost.