### PR TITLE
feat(docker): Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# Use golang:1.23.1-alpine as the base image.
+FROM golang:1.23.1-alpine AS builder
+COPY . /app
+# Change directory and build the binary. Build command is also used to download the dependencies.
+RUN cd /app && go build -o bwuagent ./cmd/api
+
+FROM chainguard/static:latest-glibc
+COPY --from=builder /app/bwuagent /usr/bin/
+# Set the default GIN_MODE to release, so that the application runs in production mode. However, this can be overridden by setting the GIN_MODE environment variable.
+ENV GIN_MODE=release
+CMD ["/usr/bin/bwuagent"]


### PR DESCRIPTION
Add Dockerfile with multi stage build support.

---

Build Image: [golang:1.23.1-alpine](https://hub.docker.com/layers/library/golang/1.23.1-alpine/images/sha256-3058c543b93017c20123f4ffe8ca779c88ade0102361ab9a290bf7d590360fc4?context=explore)
Final Image: [chainguard/static:latest-glibc](https://hub.docker.com/layers/chainguard/static/latest-glibc/images/sha256-77438bc1df55937421ed61805abc4d7f772c2713aa2fe0691fa7dc26f4600921?context=explore)

On the final image we are setting GIN_MODE to `release` but users can override it with `-e GIN_MODE=debug` flag while using docker run.

## Build

```shell
docker buildx build -f Dockerfile . -t bwuagent
```

## Run

```shell
docker run -v /etc/os-release:/etc/os-release:ro \
    -p 3000:3000 \
    -e API_SECRET=REPLACE_WITH_YOUR_SECRET \
    bwuagent:latest
```