### PR TITLE
docs: Add Docker Compose quick start instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ services:
   capture:
     image: ghcr.io/bluewave-labs/capture:latest
     container_name: capture
+    restart: unless-stopped
     ports:
       - "59232:59232"
     environment:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Quick Start (Docker Compose)" section to the README, providing a sample Docker Compose configuration for running the Capture service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->