### PR TITLE
feat: Add more build metadata like commit hash, commit date, build date and git tag

### DIFF
--- a/cmd/capture/main.go
+++ b/cmd/capture/main.go
@@ -33,8 +33,6 @@ var (
 	CompiledAt = "unknown"
 	// GitTag contains the Git tag associated with the build, if any.
 	GitTag = "unknown"
-	// GitTagURL holds the URL of the Git tag, if any.
-	GitTagURL = "https://github.com/bluewave-labs/capture/releases/tag/" + GitTag
 )
 
 func main() {
@@ -50,7 +48,6 @@ func main() {
 		fmt.Printf("Commit Date      : %s\n", CommitDate)
 		fmt.Printf("Compiled At      : %s\n", CompiledAt)
 		fmt.Printf("Git Tag          : %s\n", GitTag)
-		fmt.Printf("Git Tag URL      : %s\n", GitTagURL)
 		os.Exit(0)
 	}
 
@@ -60,12 +57,7 @@ func main() {
 	)
 
 	srv := server.NewServer(appConfig, nil, &handler.CaptureMeta{
-		Version:    Version,
-		Commit:     Commit,
-		CommitDate: CommitDate,
-		CompiledAt: CompiledAt,
-		GitTag:     GitTag,
-		GitTagURL:  GitTagURL,
+		Version: Version,
 	})
 	log.Println("WARNING: Remember to add http://" + server.GetLocalIP() + ":" + appConfig.Port + "/api/v1/metrics to your Checkmate Infrastructure Dashboard. Without this endpoint, system metrics will not be displayed.")
 

--- a/internal/server/handler/types.go
+++ b/internal/server/handler/types.go
@@ -9,11 +9,6 @@ type APIResponse struct {
 }
 
 type CaptureMeta struct {
-	Version    string `json:"version"`
-	Mode       string `json:"mode"`
-	Commit     string `json:"commit"`
-	CommitDate string `json:"commit_date"`
-	CompiledAt string `json:"compiled_at"`
-	GitTag     string `json:"git_tag"`
-	GitTagURL  string `json:"git_tag_url"`
+	Version string `json:"version"`
+	Mode    string `json:"mode"`
 }


### PR DESCRIPTION
## Summary

Extend Capture metadata to include more build information when execute `capture --version`

- Build commit has
- Date of the build commit
- Build date time
- Git Tag

Fixes: #92 

## CLI

Execute capture with --version flag

```shell
capture --version
```

Output

```shell
Capture Build Information
-------------------------
Version          : 1.3.0-SNAPSHOT-f9dc4b8
Commit Hash      : f9dc4b8b8267d88cb55a1433ebb5474bda3785c0
Commit Date      : 2025-08-20T14:26:08Z
Compiled At      : 2025-08-20T14:26:21Z
Git Tag          : v1.3.0
```

## API

```shell
curl -s -X GET "http://localhost:59232/api/v1/metrics" \
    -H "Authorization: Bearer abc" \
    -H "Accept: application/json" | jq '.capture'
```

```shell
{
  "version": "1.3.0-SNAPSHOT-f9dc4b8",
  "mode": "release"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enhanced -version output now shows detailed build information: Version, Commit, CommitDate, CompiledAt, and GitTag.

- Chores
  - Binaries now embed build metadata (commit, commit date, build time, git tag) via standardized build flags.
  - Consolidated build flag configuration for consistency across build targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->