### PR TITLE
feat: Add reverse proxy setup with Caddy

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@
 
 Capture is a hardware monitoring agent that collects hardware information from the host machine and exposes it through a RESTful API. The agent is designed to be lightweight and easy to use.
 
+- [Features](#features)
+- [Quick Start (Docker)](#quick-start-docker)
+- [Quick Start (Docker Compose)](#quick-start-docker-compose)
+- [Configuration](#configuration)
+- [Installation Options](#installation-options)
+  - [Docker (Recommended)](#docker-recommended)
+- [System Installation](#system-installation)
+- [Reverse Proxy and SSL](#reverse-proxy-and-ssl)
+  - [Caddy](#caddy)
+- [API Documentation](#api-documentation)
+- [Contributing](#contributing)
+- [Star History](#star-history)
+- [License](#license)
+
 ## Features
 
 - CPU Monitoring
@@ -126,6 +140,36 @@ Choose one of these methods:
    cd capture
    just build   # or: go build -o dist/capture ./cmd/capture/
    ```
+
+## Reverse Proxy and SSL
+
+You can use a reverse proxy in front of the Capture service to handle HTTPS requests and SSL termination.
+
+### Caddy
+
+```lua
+├deployment/reverse-proxy-compose/
+├── caddy/
+│   └── Caddyfile
+└── caddy.compose.yml
+```
+
+1. Go to the `deployment/reverse-proxy-compose` directory
+
+    ```shell
+    cd deployment/reverse-proxy-compose
+    ```
+
+2. Replace `replacewithyourdomain.com` with your actual domain in [deployment/reverse-proxy-compose/caddy/Caddyfile](./deployment/reverse-proxy-compose/caddy/Caddyfile)
+3. Set `API_SECRET` environment variable for the Capture service in [deployment/reverse-proxy-compose/caddy.compose.yml](./deployment/reverse-proxy-compose/caddy.compose.yml).
+4. Ensure your domain’s DNS A/AAAA records point to this server’s IP.
+5. Open inbound TCP ports 80 and 443 on your firewall/security group.
+
+Start the Caddy reverse proxy
+
+```shell
+docker compose -f caddy.compose.yml up -d
+```
 
 ## API Documentation
 

--- a/deployment/reverse-proxy-compose/caddy.compose.yml
+++ b/deployment/reverse-proxy-compose/caddy.compose.yml
@@ -1,0 +1,33 @@
+networks:
+  capture-network:
+    driver: bridge
+
+services:
+  caddy:
+    image: caddy:2.10-alpine
+    container_name: caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./caddy/Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data
+    networks:
+      - capture-network
+
+  capture:
+    image: ghcr.io/bluewave-labs/capture:latest
+    restart: unless-stopped
+    expose:
+      - "59232"
+    environment:
+      - API_SECRET=REPLACE_WITH_YOUR_SECRET
+      - GIN_MODE=release
+    volumes:
+      - /etc/os-release:/etc/os-release:ro
+    networks:
+      - capture-network
+
+volumes:
+  caddy_data:

--- a/deployment/reverse-proxy-compose/caddy/Caddyfile
+++ b/deployment/reverse-proxy-compose/caddy/Caddyfile
@@ -1,0 +1,3 @@
+replacewithyourdomain.com {
+  reverse_proxy capture:59232
+}


### PR DESCRIPTION
Created a new directory `deployment`. I was using docs directory to keep some deployment stuff but using separate deployment directory is good for new comers.

**Deployment Directory**
```lua
├── caddy/
│   └── Caddyfile
└── caddy.compose.yml
```

## [CaddyServer](https://caddyserver.com)

I created a sample docker compose file for using Capture with Caddy. Caddy has built-in SSL support so we don't need to manually configure everything. It's simple and straightforward.

You can see the docs on README.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ready-to-use reverse proxy setup using Caddy and Docker Compose for SSL termination and a shared network; includes guidance to set your domain and API secret and quick-start launch steps.

* **Documentation**
  * Added a Reverse Proxy & SSL section with Caddy setup steps, sample directory layout, step-by-step launch instructions, updated table of contents, and an OpenAPI link near the new content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->