### PR TITLE
Fix disk metrics for LVM devices (resolve /dev/mapper to dm-*)

### DIFF
--- a/internal/metric/disk.go
+++ b/internal/metric/disk.go
@@ -1,6 +1,7 @@
 package metric
 
 import (
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -24,7 +25,6 @@ func isDevPrefixed(p disk.PartitionStat) bool {
 
 // isWindowsDrive checks if the device is a Windows drive (C:, D:, etc.).
 func isWindowsDrive(p disk.PartitionStat) bool {
-	// Windows drives typically look like "C:", "D:", etc.
 	device := strings.TrimSpace(p.Device)
 	if len(device) >= 2 {
 		return device[1] == ':' && ((device[0] >= 'A' && device[0] <= 'Z') || (device[0] >= 'a' && device[0] <= 'z'))
@@ -99,7 +99,7 @@ func collectPartitionMetrics(partition disk.PartitionStat) (*DiskData, CustomErr
 		return nil, *usageErr
 	}
 
-	// Combine all metrics into DiskData structure
+	// Combine all metrics into a DiskData structure
 	return &DiskData{
 		Device:       partition.Device,
 		TotalBytes:   &usageStats.Total,
@@ -119,31 +119,80 @@ func collectPartitionMetrics(partition disk.PartitionStat) (*DiskData, CustomErr
 	}, CustomErr{}
 }
 
-// collectIOStats collects IO-related metrics for a device.
+// collectIOStats gathers IO-related metrics for a device.
+// Supports LVM/device-mapper by resolving /dev/mapper/* -> /dev/dm-*
+// and trying multiple key candidates against the map returned by disk.IOCounters().
 func collectIOStats(device string) (*disk.IOCountersStat, *CustomErr) {
-	diskIOCounts, diskIOErr := disk.IOCounters(device)
-	if diskIOErr != nil {
+	// Get all counters once and look up by key
+	all, err := disk.IOCounters()
+	if err != nil {
 		return nil, &CustomErr{
 			Metric: []string{"disk.read_bytes", "disk.write_bytes", "disk.read_time", "disk.write_time"},
-			Error:  diskIOErr.Error() + " " + device,
+			Error:  err.Error() + " " + device,
 		}
 	}
 
-	// Extract device name for lookup (handle cross-platform differences)
-	deviceName := device
-	if runtime.GOOS != "windows" {
-		deviceName = strings.TrimPrefix(device, "/dev/")
-	}
+	candidates := buildDeviceKeyCandidates(device)
 
-	stats, exists := diskIOCounts[deviceName]
-	if !exists {
-		return nil, &CustomErr{
-			Metric: []string{"disk.read_bytes", "disk.write_bytes", "disk.read_time", "disk.write_time"},
-			Error:  "device stats not found: " + device,
+	// 1) Direct map key match
+	for _, k := range candidates {
+		if stat, ok := all[k]; ok {
+			return &stat, nil
 		}
 	}
 
-	return &stats, nil
+	// 2) Fallback: match by stat.Name field
+	for _, stat := range all {
+		for _, k := range candidates {
+			if stat.Name == k {
+				s := stat
+				return &s, nil
+			}
+		}
+	}
+
+	return nil, &CustomErr{
+		Metric: []string{"disk.read_bytes", "disk.write_bytes", "disk.read_time", "disk.write_time"},
+		Error:  "device stats not found: " + device + " (tried: " + strings.Join(candidates, ", ") + ")",
+	}
+}
+
+// buildDeviceKeyCandidates returns possible keys for the disk.IOCounters() map.
+// Handles paths like /dev/sda, /dev/nvme0n1, /dev/mapper/vg-lv -> dm-0, etc.
+func buildDeviceKeyCandidates(device string) []string {
+	if runtime.GOOS == "windows" {
+		// On Windows, gopsutil uses names like "C:", so keep as-is.
+		d := strings.TrimSpace(device)
+		return []string{d}
+	}
+
+	var out []string
+	d := strings.TrimSpace(device)
+
+	// Strip /dev/
+	out = append(out, strings.TrimPrefix(d, "/dev/"))
+	// Basename (e.g., /dev/mapper/vg-lv -> vg-lv)
+	out = append(out, filepath.Base(d))
+
+	// Resolve symlinks: /dev/mapper/vg-lv -> /dev/dm-0 -> dm-0
+	if resolved, err := filepath.EvalSymlinks(d); err == nil && resolved != "" {
+		out = append(out, strings.TrimPrefix(resolved, "/dev/"))
+		out = append(out, filepath.Base(resolved))
+	}
+
+	// Deduplicate
+	seen := map[string]struct{}{}
+	uniq := make([]string, 0, len(out))
+	for _, k := range out {
+		if k == "" {
+			continue
+		}
+		if _, ok := seen[k]; !ok {
+			seen[k] = struct{}{}
+			uniq = append(uniq, k)
+		}
+	}
+	return uniq
 }
 
 // collectUsageStats collects usage-related metrics for a mountpoint.
@@ -161,9 +210,9 @@ func collectUsageStats(mountpoint string) (*disk.UsageStat, *CustomErr) {
 }
 
 // CollectDiskMetrics collects disk metrics following the disk metric flow specification.
-// List all partitions on the system using disk.Partitions(all=true)
-// Check each partition for filtering conditions
-// For each valid partition, gather the specified metrics
+// Lists all partitions on the system using disk.Partitions(all=true).
+// Checks each partition for filtering conditions.
+// For each valid partition, gathers the specified metrics.
 func CollectDiskMetrics() (MetricsSlice, []CustomErr) {
 	defaultDiskData := []*DiskData{
 		{
@@ -185,9 +234,9 @@ func CollectDiskMetrics() (MetricsSlice, []CustomErr) {
 
 	var diskErrors []CustomErr
 	var metricsSlice MetricsSlice
-	var checkedDevices = make(map[string]struct{}) // To keep track of checked partitions
+	var checkedDevices = make(map[string]struct{}) // Track already processed devices
 
-	// List all partitions on the system. Using disk.Partitions(all=true)
+	// List all partitions on the system
 	partitions, partErr := disk.Partitions(true)
 	if partErr != nil {
 		diskErrors = append(diskErrors, CustomErr{
@@ -197,26 +246,26 @@ func CollectDiskMetrics() (MetricsSlice, []CustomErr) {
 		return MetricsSlice{defaultDiskData[0]}, diskErrors
 	}
 
-	// Check each partition for the filtering
+	// Iterate through partitions and apply filters
 	for _, partition := range partitions {
-		// Check if the partition is already checked to avoid duplicates
+		// Skip duplicates
 		if _, ok := checkedDevices[partition.Device]; ok {
 			continue
 		}
 
-		// Apply filtering logic based on the disk metric flow
+		// Apply filtering logic
 		if !shouldIncludePartition(partition) {
 			continue
 		}
 
-		// For each valid partition, gather the specified metrics
+		// Gather metrics for valid partitions
 		diskMetrics, err := collectPartitionMetrics(partition)
 		if err.Error != "" {
 			diskErrors = append(diskErrors, err)
 			continue
 		}
 
-		checkedDevices[partition.Device] = struct{}{} // Mark this partition as checked
+		checkedDevices[partition.Device] = struct{}{} // Mark as checked
 		metricsSlice = append(metricsSlice, diskMetrics)
 	}
 


### PR DESCRIPTION
### What
Fixes disk metrics not appearing for LVM or device-mapper volumes.

### Why
Previously, collectIOStats stripped `/dev/` and failed to match keys like `dm-0` in disk.IOCounters().

### How
- Resolve symlinks (/dev/mapper/* → /dev/dm-*)
- Build multiple candidate keys for lookup (raw, basename, resolved)
- Fallback to comparing stat.Name

### Result
Disk metrics now appear correctly on LVM and other mapped devices without affecting regular or Windows disks.
